### PR TITLE
FEAT: support optional external checks flags 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,13 @@ inputs:
   framework:
     description: 'run only on a specific infrastructure'
     required: false
+  external_checks_dirs:
+    description: 'comma separated list of external (custom) checks directories'
+    required: false
+  external_checks_repos:
+    description: 'comma separated list of external (custom) checks repositories'
+    required: false
+
 branding:
   icon: 'shield'
   color: 'purple'
@@ -31,3 +38,5 @@ runs:
     - ${{ inputs.skip_check }}
     - ${{ inputs.quiet }}
     - ${{ inputs.framework }}
+    - ${{ inputs.external_checks_dirs }}
+    - ${{ inputs.external_checks_repos }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,4 +31,4 @@ cp /usr/local/lib/checkov-problem-matcher.json "$matcher_path"
 
 echo "::add-matcher::checkov-problem-matcher.json"
 echo "running checkov on directory: $1"
-echo "checkov -d $INPUT_DIRECTORY $CHECK_FLAG $SKIP_CHECK_FLAG $QUIET_FLAG $FRAMEWORK_FLAG $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG"
+checkov -d $INPUT_DIRECTORY $CHECK_FLAG $SKIP_CHECK_FLAG $QUIET_FLAG $FRAMEWORK_FLAG $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,10 +6,29 @@
 [[ ! -z "$INPUT_QUIET" ]] && QUIET_FLAG="--quiet"
 [[ ! -z "$INPUT_FRAMEWORK" ]] && FRAMEWORK_FLAG="--framework $INPUT_FRAMEWORK"
 
+EXTCHECK_DIRS_FLAG=""
+if [ ! -z "$INPUT_EXTERNAL_CHECKS_DIRS" ]; then
+  IFS=', ' read -r -a extchecks_dir <<< "$INPUT_EXTERNAL_CHECKS_DIRS"
+  for d in "${extchecks_dir[@]}"
+  do
+    EXTCHECK_DIRS_FLAG="$EXTCHECK_DIRS_FLAG --external-checks-dir $d"
+  done
+fi
+
+EXTCHECK_REPOS_FLAG=""
+if [ ! -z "$INPUT_EXTERNAL_CHECKS_REPOS" ]; then
+  IFS=', ' read -r -a extchecks_git <<< "$INPUT_EXTERNAL_CHECKS_REPOS"
+  for repo in "${extchecks_git[@]}"
+  do
+    EXTCHECK_REPOS_FLAG="$EXTCHECK_REPOS_FLAG --external-checks-git $repo"
+  done
+fi
+
+
 matcher_path=`pwd`/checkov-problem-matcher.json
 
 cp /usr/local/lib/checkov-problem-matcher.json "$matcher_path"
 
 echo "::add-matcher::checkov-problem-matcher.json"
 echo "running checkov on directory: $1"
-checkov -d $INPUT_DIRECTORY $CHECK_FLAG $SKIP_CHECK_FLAG $QUIET_FLAG $FRAMEWORK_FLAG
+echo "checkov -d $INPUT_DIRECTORY $CHECK_FLAG $SKIP_CHECK_FLAG $QUIET_FLAG $FRAMEWORK_FLAG $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG"


### PR DESCRIPTION
 support --external-checks-{git,dir}. Multiple entries support (comma separated)