### PR TITLE
Lint Result

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 echo "input_soft_fail:$INPUT_SOFT_FAIL"
 matcher_path=`pwd`/checkov-problem-matcher.json
-if [ ! -z "$INPUT_SOFT_FAIL"]; then
+if [ ! -z "$INPUT_SOFT_FAIL" ]; then
     cp /usr/local/lib/checkov-problem-matcher.json "$matcher_path"
     else
     cp /usr/local/lib/checkov-problem-matcher-softfail.json "$matcher_path"


### PR DESCRIPTION
Hello,

Adding some whitespace to be consistent with the rest of the file.

I found this because I use the action and it reports some sort of static analysis running at the beginning of the run (see below). Hopefully this will fix that.

```
/entrypoint.sh: line 37: [: missing `]'
input_soft_fail:false
running checkov on directory: modules/
```