### PR TITLE
remove .external_modules after scaning  if  download-external-modules  enabled

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,3 +47,9 @@ fi
 echo "::add-matcher::checkov-problem-matcher.json"
 echo "running checkov on directory: $1"
 checkov -d $INPUT_DIRECTORY $CHECK_FLAG $SKIP_CHECK_FLAG $QUIET_FLAG $SOFT_FAIL_FLAG $FRAMEWORK_FLAG $EXTCHECK_DIRS_FLAG $EXTCHECK_REPOS_FLAG $OUTPUT_FLAG $DOWNLOAD_EXTERNAL_MODULES_FLAG
+
+if [ ! -z "$INPUT_DOWNLOAD_EXTERNAL_MODULES" ] && [ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" = "true" ]; then
+  echo "Cleaning up $INPUT_DIRECTORY/.external_modules directory"
+  #This directory must be removed here for the self hosted github runners run as non-root user.
+  rm -fr $INPUT_DIRECTORY/.external_modules
+fi


### PR DESCRIPTION
self hosted github runners run as non-root user.  
If  `--download-external-modules` specified, it creates `.external_modules`  in scanned folder as root user.
And github runner can't delete it.