### PR TITLE
Fix typo "Github" to "GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Maintained by Bridgecrew.io](https://img.shields.io/badge/maintained%20by-bridgecrew.io-blueviolet)](https://bridge.dev/2WBms5Q)
 [![slack-community](https://slack.bridgecrew.io/badge.svg)](https://slack.bridgecrew.io/?utm_source=github&utm_medium=organic_oss&utm_campaign=checkov-action)
 
-# Checkov Github action
+# Checkov GitHub action
 
-This Github Action runs [Checkov](https://github.com/bridgecrewio/checkov) against an Infrastructure-as-Code repository.
+This GitHub Action runs [Checkov](https://github.com/bridgecrewio/checkov) against an Infrastructure-as-Code repository.
 Checkov performs static security analysis of Terraform & CloudFormation Infrastructure code .
 
 ## Example usage

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 # action.yml
-name: 'Checkov Github Action'
+name: 'Checkov GitHub Action'
 author: 'Chris Mavrakis'
-description: 'Run Checkov against Terraform/CloudFormation infrastructure code, as a pre-packaged Github Action.'
+description: 'Run Checkov against Terraform/CloudFormation infrastructure code, as a pre-packaged GitHub Action.'
 inputs:
   directory:
     description: 'directory with infrastructure code to scan'


### PR DESCRIPTION
## What

Fix the type `Github` in all files.

## Why
Tiny typo.