### PR TITLE
Document SARIF output format and make it the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           quiet: true # optional: display only failed checks
           soft_fail: true # optional: do not return an error code if there are failed checks
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
-          output_format: json # optional: the output format, one of: cli, json, junitxml, github_failed_only
+          output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarf. Default: sarif
           download_external_modules: true # optional: download external terraform modules from public git repositories and terraform registry
           log_level: DEBUG # optional: set log level. Default WARNING
           config_file: path/this_file

--- a/action.yml
+++ b/action.yml
@@ -32,8 +32,9 @@ inputs:
     description: 'comma separated list of external (custom) checks repositories'
     required: false
   output_format:
-    description: 'The format of the output. cli, json, junitxml, github_failed_only'
+    description: 'The format of the output. cli, json, junitxml, github_failed_only, or sarif'
     required: false
+    default: 'sarif'
   download_external_modules:
     description: 'download external terraform modules from public git repositories and terraform registry:true, false'
     required: false


### PR DESCRIPTION
Fixes #68 

Add sarif to the parameter documentation and make it the default.