### PR TITLE
Update major tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
           if [ "$tag_commit" == "$commit" ]
           then
             echo "No new commits since previous tag. Skipping..."
-            echo ::set-output name=tag::$tag
             exit 0
           fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: version-tag-mayor
+      - name: version-tag-major
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,41 +12,32 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - name: update-release
+      - name: update-checkov-version
         run: |
-          # update checkov version
           version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
 
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: git_auto_commit
         with:
           commit_message: Bump checkov container version
 
       - name: version-tag
         uses: anothrNick/github-tag-action@1.39.0
+        if: steps.git_auto_commit.outputs.changes_detected == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
 
       - name: version-tag-major
+        if: steps.git_auto_commit.outputs.changes_detected == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git fetch --tags
           tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
           tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | head -n 1)"
-          
-          # get current commit hash for tag
-          tag_commit=$(git rev-list -n 1 ${tag})
-          # get current commit hash
-          commit=$(git rev-parse HEAD)
-
-          if [ "$tag_commit" == "$commit" ]
-          then
-            echo "No new commits since previous tag. Skipping..."
-            exit 0
-          fi
 
           [[ "$tag" =~ ^(v[0-9]+) ]]
           major=${BASH_REMATCH[1]}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
       - name: update-release
         run: |
           # update checkov version
@@ -25,10 +28,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
 
       - name: version-tag-major
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,19 +7,53 @@ jobs:
   update-checkov:
     runs-on: [self-hosted, public, linux, x64]
     steps:
+
       - uses: actions/checkout@v2
-      - name: update release
+      - name: update-release
         run: |
           # update checkov version
           version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
+
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Bump checkov container version
-      - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.17.2
+
+      - name: version-tag
+        uses: anothrNick/github-tag-action@1.39.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: version-tag-mayor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+        run: |
+          git fetch --tags
+          tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"
+          tag="$(git for-each-ref --sort=-v:refname --format '%(refname:lstrip=2)' | grep -E "$tagFmt" | head -n 1)"
+          
+          # get current commit hash for tag
+          tag_commit=$(git rev-list -n 1 ${tag})
+          # get current commit hash
+          commit=$(git rev-parse HEAD)
+
+          if [ "$tag_commit" == "$commit" ]
+          then
+            echo "No new commits since previous tag. Skipping..."
+            echo ::set-output name=tag::$tag
+            exit 0
+          fi
+
+          [[ "$tag" =~ ^(v[0-9]+) ]]
+          major=${BASH_REMATCH[1]}
+
+          # update major tag
+          git tag -f "$major"
+          git push -f --tags

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
       - name: version-tag-major
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
         run: |
           git fetch --tags
           tagFmt="^v?[0-9]+\.[0-9]+\.[0-9]+$"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: [self-hosted, public, linux, x64]
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: update-release
         run: |
           # update checkov version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
 
           # update major tag
           git tag -f "$major"
-          git push -f --tags
+          git push -f origin "$major"


### PR DESCRIPTION
If you use dependabot in your actions. Checkov is the most annoying of all bumping patch versions almost everyday. Lets have a major tag update as well.

Bump major to facilitate 

```
      - name: checkov
        uses: bridgecrewio/checkov-action@v12
```
as well of
```
      - name: checkov
        uses: bridgecrewio/checkov-action@v12.1708.0
```