### PR TITLE
Pull release body from upstream for commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       - name: update-checkov-version
         run: |
           version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
-          changes=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.body')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
           echo "CHECKOV_VERSION=$version" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,21 @@ jobs:
       - name: update-checkov-version
         run: |
           version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
+          changes=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.body')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
+          echo "CHECKOV_VERSION=$version" >> $GITHUB_ENV
+          echo "CHECKOV_CHANGES<<EOF" >> $GITHUB_ENV
+          echo "$changes" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV\
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         id: git_auto_commit
         with:
-          commit_message: Bump checkov container version
+          commit_message: |
+            Bump checkov container version to ${{ env.CHECKOV_VERSION }}
+            
+            ${{ env.CHECKOV_CHANGES }}
 
       - name: version-tag
         uses: anothrNick/github-tag-action@1.39.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,22 @@ jobs:
   update-checkov:
     runs-on: [self-hosted, public, linux, x64]
     steps:
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
 
       - name: update-checkov-version
+        id: checkov_version
         run: |
           version=$(curl -s https://api.github.com/repos/bridgecrewio/checkov/releases/latest | jq -r '.name')
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
-          echo "CHECKOV_VERSION=$version" >> $GITHUB_ENV
+          echo "::set-output name=version::$version"
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         id: git_auto_commit
         with:
-          commit_message: Bump checkov container version to ${{ env.CHECKOV_VERSION }}
+          commit_message: Bump checkov container version to ${{ steps.checkov_version.outputs.version }}
 
       - name: version-tag
         uses: anothrNick/github-tag-action@1.39.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,11 @@ jobs:
           sed -i'.bkp' -e 's/docker:\/\/bridgecrew\/checkov.*'\''/docker:\/\/bridgecrew\/checkov:'"${version}"''\''/g' action.yml
           rm action.yml.bkp
           echo "CHECKOV_VERSION=$version" >> $GITHUB_ENV
-          echo "CHECKOV_CHANGES<<EOF" >> $GITHUB_ENV
-          echo "$changes" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV\
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         id: git_auto_commit
         with:
-          commit_message: |
-            Bump checkov container version to ${{ env.CHECKOV_VERSION }}
-            
-            ${{ env.CHECKOV_CHANGES }}
+          commit_message: Bump checkov container version to ${{ env.CHECKOV_VERSION }}
 
       - name: version-tag
         uses: anothrNick/github-tag-action@1.39.0


### PR DESCRIPTION
This should pull the body of the commits from upstream into the update commit messages in this repo, which will make dependabot updates to the github action much more useful for consumers of the action.

Closes https://github.com/bridgecrewio/checkov-action/issues/95