### PR TITLE
add --var-file parameter to checkov action

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
           output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
           download_external_modules: true # optional: download external terraform modules from public git repositories and terraform registry
+          var_file: ./testdir/gocd.yaml # optional: Use custom values file when scanning a Helm Chart
           log_level: DEBUG # optional: set log level. Default WARNING
           config_file: path/this_file
           baseline: cloudformation/.checkov.baseline # optional: Path to a generated baseline file. Will only report results not in the baseline.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
           output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
           download_external_modules: true # optional: download external terraform modules from public git repositories and terraform registry
-          var_file: ./testdir/gocd.yaml # optional: Use custom values file when scanning a Helm Chart
+          var_file: ./testdir/gocd.yaml # optional: variable files to load in addition to the default files. Currently only supported for source Terraform and Helm chart scans.
           log_level: DEBUG # optional: set log level. Default WARNING
           config_file: path/this_file
           baseline: cloudformation/.checkov.baseline # optional: Path to a generated baseline file. Will only report results not in the baseline.

--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ inputs:
     description: 'Path to the Dockerfile of the scanned docker image'
     required: false
   var_file:
-    description: 'Use custom values file when scanning a Helm Chart'
+    description: 'Variable files to load in addition to the default files. Currently only supported for source Terraform (.tf file), and Helm chart scans. Requires using --directory, not --file.'
     required: false
   github_pat:
     description: 'Environment variable name for a Github personal access token for scanning external modules sourced from private repositories'

--- a/action.yml
+++ b/action.yml
@@ -70,6 +70,9 @@ inputs:
   dockerfile_path:
     description: 'Path to the Dockerfile of the scanned docker image'
     required: false
+  var_file:
+    description: 'Use custom values file when scanning a Helm Chart'
+    required: false
   github_pat:
     description: 'Environment variable name for a Github personal access token for scanning external modules sourced from private repositories'
     required: false
@@ -124,6 +127,7 @@ runs:
     - ${{ inputs.soft_fail_on }}
     - ${{ inputs.docker_image }}
     - ${{ inputs.dockerfile_path }}
+    - ${{ inputs.var_file }}
     - "--user ${{ inputs.container_user }}"  
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}


### PR DESCRIPTION
add --var-file parameter to checkov action in order to specify which values file to use when scanning a helm c
hart