### PR TITLE
fix: add support for output-file-path param

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
           soft_fail: true # optional: do not return an error code if there are failed checks
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
           output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
+          output_file_path: reports/results.sarif # folder and name of results file
           download_external_modules: true # optional: download external terraform modules from public git repositories and terraform registry
           var_file: ./testdir/gocd.yaml # optional: variable files to load in addition to the default files. Currently only supported for source Terraform and Helm chart scans.
           log_level: DEBUG # optional: set log level. Default WARNING

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
     description: 'The format of the output. cli, json, junitxml, github_failed_only, or sarif'
     required: false
     default: 'sarif'
+  output_file_path:
+    description: Path and name for output file.
+    required: false
   download_external_modules:
     description: 'download external terraform modules from public git repositories and terraform registry:true, false'
     required: false
@@ -119,6 +122,7 @@ runs:
     - ${{ inputs.external_checks_dirs }}
     - ${{ inputs.external_checks_repos }}
     - ${{ inputs.output_format }}
+    - ${{ inputs.output_file_path }}
     - ${{ inputs.download_external_modules }}
     - ${{ inputs.log_level }}
     - ${{ inputs.config_file }}
@@ -128,7 +132,7 @@ runs:
     - ${{ inputs.docker_image }}
     - ${{ inputs.dockerfile_path }}
     - ${{ inputs.var_file }}
-    - "--user ${{ inputs.container_user }}"  
+    - "--user ${{ inputs.container_user }}"
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}
     GITHUB_PAT: ${{ inputs.github_pat }}


### PR DESCRIPTION
# Overview

This PR adds a new parameter named `output_file_path` which will allow the user to specify the name and location of the results file.

Closes #30 
