### PR TITLE
output CLI and SARIF output at the same time

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,13 @@ inputs:
     description: 'comma separated list of external (custom) checks repositories'
     required: false
   output_format:
-    description: 'The format of the output. cli, json, junitxml, github_failed_only, or sarif'
+    description: 'The format of the output. cli, json, junitxml, github_failed_only, or sarif (comma separated)'
     required: false
-    default: 'sarif'
+    default: 'cli,sarif'
   output_file_path:
-    description: Path and name for output file.
+    description: 'Path and name for output file, needs to end with a comma for a single output format'
     required: false
-    default: 'results.sarif'
+    default: 'console,results.sarif'
   download_external_modules:
     description: 'download external terraform modules from public git repositories and terraform registry:true, false'
     required: false


### PR DESCRIPTION
After merging bridgecrewio/checkov#4517 this will support both CLI output and SARIF to `results.sarif`