### PR TITLE
Updates flags for Github Actions to add support for skip-frameworks, skip-cve-package & output-bc-ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ jobs:
           quiet: true # optional: display only failed checks
           soft_fail: true # optional: do not return an error code if there are failed checks
           framework: terraform # optional: run only on a specific infrastructure {cloudformation,terraform,kubernetes,all}
+          skip_framework: terraform # optional: skip a specific infrastructure {cloudformation,terraform,kubernetes,all}
+          skip_cve_package: CVE_2019_8331 # optional: skip a specific CVE package in SCA scans, can be comma separated list
           output_format: sarif # optional: the output format, one of: cli, json, junitxml, github_failed_only, or sarif. Default: sarif
           output_file_path: reports/results.sarif # folder and name of results file
+          output_bc_ids: true # optional: output Bridgecrew platform IDs instead of checkov IDs
           download_external_modules: true # optional: download external terraform modules from public git repositories and terraform registry
           repo_root_for_plan_enrichment: example/ #optional: Directory containing the hcl code used to generate a given terraform plan file. Use together with `file`
           var_file: ./testdir/gocd.yaml # optional: variable files to load in addition to the default files. Currently only supported for source Terraform and Helm chart scans.
@@ -92,6 +95,7 @@ jobs:
           baseline: cloudformation/.checkov.baseline # optional: Path to a generated baseline file. Will only report results not in the baseline.
           container_user: 1000 # optional: Define what UID and / or what GID to run the container under to prevent permission issues
           use_enforcement_rules: true # optional - use enforcement rule configs from the platform
+          openai_api_key: true # optional - use OpenAI to enhance finding guidelines. This will send Code to OpenAI
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ jobs:
           baseline: cloudformation/.checkov.baseline # optional: Path to a generated baseline file. Will only report results not in the baseline.
           container_user: 1000 # optional: Define what UID and / or what GID to run the container under to prevent permission issues
           use_enforcement_rules: true # optional - use enforcement rule configs from the platform
-          openai_api_key: true # optional - use OpenAI to enhance finding guidelines. This will send Code to OpenAI
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,10 @@ inputs:
     description: 'Path (file or directory) to skip, using regular expression logic, relative to the current working directory. Word boundaries are not implicit; i.e., specifying "dir1" will skip any directory or subdirectory named "dir1". Ignored with -f. (comma separated)'
     required: false
   skip_cve_package:
-    description: 'Filter scan to run on all packages except for a specific CVE package identifier'
+    description: 'Filter scan to run on all packages except for a specific CVE package identifier, e.g. CVE-2018-19788 (comma separated)'
+    required: false
+  openai_api_key:
+    description: 'Add an OpenAI API key to enhance finding guidelines. This will send Code to OpenAI'
     required: false
 outputs:
   results:
@@ -168,6 +171,7 @@ runs:
     - ${{ inputs.policy_metadata_filter }}
     - ${{ inputs.skip_path }}
     - ${{ inputs.skip_cve_package }}
+    - ${{ inputs.openai_api_key }}
     - "--user ${{ inputs.container_user }}"
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   api-key:
     description: 'Environment variable name of the Bridgecrew API key from Bridgecrew app'
     required: false
+  output-bc-ids:
+    description: 'Output Bridgecrew IDs (BC...) instead of Checkov IDs (CKV...)'
+    required: false
   use_enforcement_rules:
     description: 'Use the Enforcement rules configured in the platform for hard / soft fail logic. See checkov help text for more details on the nuances of this option.'
     required: false
@@ -36,6 +39,9 @@ inputs:
     required: false
   framework:
     description: 'run only on a specific infrastructure'
+    required: false
+  skip_framework:
+    description: 'skip a specific infrastructure'
     required: false
   external_checks_dirs:
     description: 'comma separated list of external (custom) checks directories'
@@ -104,10 +110,10 @@ inputs:
     description: 'Environment variable name for a Bitbucket access token to scan external modules sourced from a private Bitbucket repository'
     required: false
   bitbucket_app_password:
-    description: 'Environment variable name for a Bitbucket app password to perform basic auth inorder to scan external modules sourced from a private Bitbucket repository. To be used with bitbucket_usernam'
+    description: 'Environment variable name for a Bitbucket app password to perform basic auth in order to scan external modules sourced from a private Bitbucket repository. To be used with bitbucket_usernam'
     required: false
   bitbucket_username:
-    description: 'Environment variable name for a Bitbucket username to perform basic auth inorder to scan external modules sourced from a private Bitbucket repository. To be used with bitbucket_app_password'
+    description: 'Environment variable name for a Bitbucket username to perform basic auth in order to scan external modules sourced from a private Bitbucket repository. To be used with bitbucket_app_password'
     required: false
   repo_root_for_plan_enrichment:
     description: 'Directory containing the hcl code used to generate a given plan file. Use with `file`'
@@ -117,6 +123,9 @@ inputs:
     required: false
   skip_path:
     description: 'Path (file or directory) to skip, using regular expression logic, relative to the current working directory. Word boundaries are not implicit; i.e., specifying "dir1" will skip any directory or subdirectory named "dir1". Ignored with -f. (comma separated)'
+    required: false
+  skip_cve_package:
+    description: 'Filter scan to run on all packages except for a specific CVE package identifier'
     required: false
 outputs:
   results:
@@ -136,9 +145,11 @@ runs:
     - ${{ inputs.compact }}
     - ${{ inputs.quiet }}
     - ${{ inputs.soft_fail }}
+    - ${{ inputs.output_bc_ids }}
     - ${{ inputs.use_enforcement_rules }}
     - ${{ inputs.skip_results_upload }}
     - ${{ inputs.framework }}
+    - ${{ inputs.skip_framework }}
     - ${{ inputs.external_checks_dirs }}
     - ${{ inputs.external_checks_repos }}
     - ${{ inputs.output_format }}
@@ -156,6 +167,7 @@ runs:
     - ${{ inputs.repo_root_for_plan_enrichment }}
     - ${{ inputs.policy_metadata_filter }}
     - ${{ inputs.skip_path }}
+    - ${{ inputs.skip_cve_package }}
     - "--user ${{ inputs.container_user }}"
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}

--- a/action.yml
+++ b/action.yml
@@ -127,9 +127,6 @@ inputs:
   skip_cve_package:
     description: 'Filter scan to run on all packages except for a specific CVE package identifier, e.g. CVE-2018-19788 (comma separated)'
     required: false
-  openai_api_key:
-    description: 'Add an OpenAI API key to enhance finding guidelines. This will send Code to OpenAI'
-    required: false
 outputs:
   results:
     description: 'The results from the infrastructure scan'
@@ -171,7 +168,6 @@ runs:
     - ${{ inputs.policy_metadata_filter }}
     - ${{ inputs.skip_path }}
     - ${{ inputs.skip_cve_package }}
-    - ${{ inputs.openai_api_key }}
     - "--user ${{ inputs.container_user }}"
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}


### PR DESCRIPTION
## Description

Adds support for the following flags:

* skip_framework
* output_bc_ids
* skip_cve_package

### Related

* https://github.com/bridgecrewio/checkov/pull/5619

fixes #149