### PR TITLE
Rebuild entrypoint.sh argv as bash array

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.11-slim
+
+ENV RUN_IN_DOCKER=True
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get -y upgrade; \
+    apt-get install -y --no-install-recommends \
+            ca-certificates \
+            git \
+            curl \
+            openssh-client \
+    ; \
+    \
+    pip install setuptools==78.1.1 urllib3==2.2.2;  \
+    curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3; \
+    chmod 700 get_helm.sh; \
+    VERIFY_CHECKSUM=true ./get_helm.sh; \
+    rm ./get_helm.sh; \
+    \
+    curl -sSLo get_kustomize.sh https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh; \
+    chmod 700 get_kustomize.sh; \
+    ./get_kustomize.sh; mv /kustomize /usr/bin/kustomize; \
+    rm ./get_kustomize.sh; \
+    \
+    apt-get remove -y curl; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir -U checkov
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY checkov-problem-matcher.json /usr/local/lib/checkov-problem-matcher.json
+COPY checkov-problem-matcher-softfail.json /usr/local/lib/checkov-problem-matcher-softfail.json
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -154,42 +154,7 @@ branding:
   color: 'purple'
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/bridgecrewio/checkov:3.2.513'
-  args:
-    - ${{ inputs.file }}
-    - ${{ inputs.directory }}
-    - ${{ inputs.check }}
-    - ${{ inputs.skip_check }}
-    - ${{ inputs.compact }}
-    - ${{ inputs.quiet }}
-    - ${{ inputs.soft_fail }}
-    - ${{ inputs.output_bc_ids }}
-    - ${{ inputs.use_enforcement_rules }}
-    - ${{ inputs.skip_results_upload }}
-    - ${{ inputs.framework }}
-    - ${{ inputs.skip_framework }}
-    - ${{ inputs.external_checks_dirs }}
-    - ${{ inputs.external_checks_repos }}
-    - ${{ inputs.output_format }}
-    - ${{ inputs.output_file_path }}
-    - ${{ inputs.download_external_modules }}
-    - ${{ inputs.enable_secrets_scan_all_files }}
-    - ${{ inputs.log_level }}
-    - ${{ inputs.config_file }}
-    - ${{ inputs.baseline }}
-    - ${{ inputs.hard_fail_on }}
-    - ${{ inputs.soft_fail_on }}
-    - ${{ inputs.docker_image }}
-    - ${{ inputs.dockerfile_path }}
-    - ${{ inputs.var_file }}
-    - ${{ inputs.repo_root_for_plan_enrichment }}
-    - ${{ inputs.deep_analysis }}
-    - ${{ inputs.policy_metadata_filter }}
-    - ${{ inputs.policy_metadata_filter_exception }}
-    - ${{ inputs.skip_path }}
-    - ${{ inputs.skip_cve_package }}
-    - ${{ inputs.skip_download }}
-    - "--user ${{ inputs.container_user }}"
+  image: 'Dockerfile'
   env:
     API_KEY_VARIABLE: ${{ inputs.api-key }}
     GITHUB_PAT: ${{ inputs.github_pat }}
@@ -203,4 +168,3 @@ runs:
     BITBUCKET_APP_PASSWORD: ${{ inputs.bitbucket_app_password }}
     PRISMA_API_URL: ${{ inputs.prisma-api-url }}
     CKV_VALIDATE_SECRETS: ${{ inputs.ckv_validate_secrets }}
-    

--- a/checkov-problem-matcher-softfail.json
+++ b/checkov-problem-matcher-softfail.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "checkov",
+      "pattern": [
+        {
+          "regexp": "^Check: (\\w+: .*)$",
+          "message": 1
+        },
+        {
+          "regexp": "^\\WFAILED.*$"
+        },
+        {
+          "regexp": "^\\WFile: \/(.+):(\\d+)-(\\d+)$",
+          "file": 1,
+          "line": 2
+        }
+      ],
+      "severity": "error"
+    }
+  ]
+}

--- a/checkov-problem-matcher.json
+++ b/checkov-problem-matcher.json
@@ -1,0 +1,21 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "checkov",
+      "pattern": [
+        {
+          "regexp": "^Check: (\\w+: .*)$",
+          "message": 1
+        },
+        {
+          "regexp": "^\\WFAILED.*$"
+        },
+        {
+          "regexp": "^\\WFile: \/(.+):(\\d+)-(\\d+)$",
+          "file": 1,
+          "line": 2
+        }
+      ]
+    }
+  ]
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+# Leverage the default env variables as described in:
+# https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
+if [[ $GITHUB_ACTIONS != "true" ]]
+then
+  checkov "$@"
+  exit $?
+fi
+
+matcher_path=`pwd`/checkov-problem-matcher.json
+warning_matcher_path=`pwd`/checkov-problem-matcher-softfail.json
+cp /usr/local/lib/checkov-problem-matcher.json "$matcher_path"
+cp /usr/local/lib/checkov-problem-matcher-softfail.json "$warning_matcher_path"
+
+export BC_SOURCE=githubActions
+
+if [ -n "$PRISMA_API_URL" ]; then
+  export PRISMA_API_URL="$PRISMA_API_URL"
+fi
+
+# Build checkov argv as a bash array so each INPUT_* value is exactly one
+# argv element. Prevents argument injection via spaces in action inputs.
+declare -a CKV_ARGS=()
+
+add_flag() {
+  # add_flag --flag "$VALUE"  -> appends iff VALUE is non-empty
+  local flag="$1" val="$2"
+  [[ -n "$val" ]] && CKV_ARGS+=("$flag" "$val")
+}
+
+add_bool() {
+  # add_bool --flag "$VALUE"  -> appends flag iff VALUE == "true"
+  local flag="$1" val="$2"
+  [[ "$val" == "true" ]] && CKV_ARGS+=("$flag")
+}
+
+add_csv() {
+  # add_csv --flag "$CSV"  -> one flag per comma-separated token
+  local flag="$1" csv="$2"
+  [[ -z "$csv" ]] && return
+  local IFS=','
+  local -a parts
+  read -r -a parts <<< "$csv"
+  local p
+  for p in "${parts[@]}"; do
+    p="${p## }"; p="${p%% }"  # trim single leading/trailing space
+    [[ -n "$p" ]] && CKV_ARGS+=("$flag" "$p")
+  done
+}
+
+# Scan target
+if [ -n "$INPUT_DOCKER_IMAGE" ]; then
+  add_flag --docker-image    "$INPUT_DOCKER_IMAGE"
+  add_flag --dockerfile-path "$INPUT_DOCKERFILE_PATH"
+elif [ -n "$INPUT_FILE" ]; then
+  CKV_ARGS+=(-f "$INPUT_FILE")
+  echo "running checkov on file: $INPUT_FILE"
+else
+  CKV_ARGS+=(-d "${INPUT_DIRECTORY:-.}")
+  echo "running checkov on directory: ${INPUT_DIRECTORY:-.}"
+fi
+
+# Single-value flags
+add_flag --skip-check                      "$INPUT_SKIP_CHECK"
+add_flag --framework                       "$INPUT_FRAMEWORK"
+add_flag --skip-framework                  "$INPUT_SKIP_FRAMEWORK"
+add_flag --output-file-path                "$INPUT_OUTPUT_FILE_PATH"
+add_flag --baseline                        "$INPUT_BASELINE"
+add_flag --config-file                     "$INPUT_CONFIG_FILE"
+add_flag --soft-fail-on                    "$INPUT_SOFT_FAIL_ON"
+add_flag --hard-fail-on                    "$INPUT_HARD_FAIL_ON"
+add_flag --repo-root-for-plan-enrichment   "$INPUT_REPO_ROOT_FOR_PLAN_ENRICHMENT"
+add_flag --policy-metadata-filter          "$INPUT_POLICY_METADATA_FILTER"
+add_flag --policy-metadata-filter-exception "$INPUT_POLICY_METADATA_FILTER_EXCEPTION"
+
+# Boolean flags
+add_bool --output-bc-ids                "$INPUT_OUTPUT_BC_IDS"
+add_bool --compact                      "$INPUT_COMPACT"
+add_bool --quiet                        "$INPUT_QUIET"
+add_bool --soft-fail                    "$INPUT_SOFT_FAIL"
+add_bool --use-enforcement-rules        "$INPUT_USE_ENFORCEMENT_RULES"
+add_bool --enable-secret-scan-all-files "$INPUT_ENABLE_SECRETS_SCAN_ALL_FILES"
+add_bool --skip-results-upload          "$INPUT_SKIP_RESULTS_UPLOAD"
+add_bool --skip-download                "$INPUT_SKIP_DOWNLOAD"
+add_bool --deep-analysis                "$INPUT_DEEP_ANALYSIS"
+[[ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" == "true" ]] && CKV_ARGS+=(--download-external-modules true)
+
+# Comma-separated multi-value flags
+add_csv --external-checks-dir "$INPUT_EXTERNAL_CHECKS_DIRS"
+add_csv --external-checks-git "$INPUT_EXTERNAL_CHECKS_REPOS"
+add_csv --check               "$INPUT_CHECK"
+add_csv --output              "$INPUT_OUTPUT_FORMAT"
+add_csv --var-file            "$INPUT_VAR_FILE"
+add_csv --skip-path           "$INPUT_SKIP_PATH"
+add_csv --skip-cve-package    "$INPUT_SKIP_CVE_PACKAGE"
+
+if [ -n "$INPUT_LOG_LEVEL" ]; then
+  export LOG_LEVEL="$INPUT_LOG_LEVEL"
+fi
+
+if [[ -z "$INPUT_SOFT_FAIL" ]]; then
+    echo "::add-matcher::checkov-problem-matcher.json"
+else
+    echo "::add-matcher::checkov-problem-matcher-softfail.json"
+fi
+
+API_KEY=${API_KEY_VARIABLE}
+
+GIT_BRANCH=${GITHUB_HEAD_REF:="$GITHUB_REF_NAME"}
+GIT_BRANCH=${GIT_BRANCH:=master}
+export BC_FROM_BRANCH=${GIT_BRANCH}
+export BC_TO_BRANCH=${GITHUB_BASE_REF}
+export BC_PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+export BC_PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${BC_PR_ID}"
+export BC_COMMIT_HASH=${GITHUB_SHA}
+export BC_COMMIT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"
+export BC_AUTHOR_NAME=${GITHUB_ACTOR}
+export BC_AUTHOR_URL="${GITHUB_SERVER_URL}/${BC_AUTHOR_NAME}"
+export BC_RUN_ID=${GITHUB_RUN_NUMBER}
+export BC_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+export BC_REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+echo "BC_FROM_BRANCH=${GIT_BRANCH}"
+echo "BC_TO_BRANCH=${GITHUB_BASE_REF}"
+echo "BC_PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"
+echo "BC_PR_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${BC_PR_ID}""
+echo "BC_COMMIT_HASH=${GITHUB_SHA}"
+echo "BC_COMMIT_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}""
+echo "BC_AUTHOR_NAME=${GITHUB_ACTOR}"
+echo "BC_AUTHOR_URL="${GITHUB_SERVER_URL}/${BC_AUTHOR_NAME}""
+echo "BC_RUN_ID=${GITHUB_RUN_NUMBER}"
+echo "BC_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}""
+echo "BC_REPOSITORY_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}""
+
+# Overrides all GitHub URLs with the provided PAT (needed for downloading private modules from GitHub)
+# This is meant to be a last resort, if our internal mechanism doesn't work
+if [ -n "$GITHUB_OVERRIDE_URL" ] && [ "$GITHUB_OVERRIDE_URL" = "true" ]; then
+  git config --global url."https://x-access-token:${GITHUB_PAT}@github.com/".insteadOf "https://github.com/"
+fi
+
+if [ -n "$API_KEY_VARIABLE" ]; then
+  CKV_ARGS+=(--bc-api-key "$API_KEY_VARIABLE"
+             --branch "$GIT_BRANCH"
+             --repo-id "$GITHUB_REPOSITORY")
+fi
+
+# Log command with API key redacted
+printf 'checkov'; for a in "${CKV_ARGS[@]}"; do
+  [[ "$a" == "$API_KEY_VARIABLE" && -n "$a" ]] && printf ' <API_KEY>' || printf ' %q' "$a"
+done; printf '\n'
+
+CHECKOV_RESULTS=$(checkov "${CKV_ARGS[@]}")
+
+CHECKOV_EXIT_CODE=$?
+
+# print to console
+echo "${CHECKOV_RESULTS}"
+
+CHECKOV_RESULTS="${CHECKOV_RESULTS//$'\\n'/''}"
+
+# save output to GitHub files for further usage
+EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+{ echo "CHECKOV_RESULTS<<$EOF"; echo "${CHECKOV_RESULTS:0:65536}"; echo "$EOF"; } >> $GITHUB_ENV
+{ echo "results<<$EOF"; echo "$CHECKOV_RESULTS"; echo "$EOF"; } >> $GITHUB_OUTPUT
+
+if [ -n "$INPUT_DOWNLOAD_EXTERNAL_MODULES" ] && [ "$INPUT_DOWNLOAD_EXTERNAL_MODULES" = "true" ]; then
+  echo "Cleaning up $INPUT_DIRECTORY/.external_modules directory"
+  #This directory must be removed here for the self hosted github runners run as non-root user.
+  rm -fr -- "${INPUT_DIRECTORY:-.}/.external_modules"
+  exit $CHECKOV_EXIT_CODE
+fi
+exit $CHECKOV_EXIT_CODE


### PR DESCRIPTION
Rebuild argv construction as a bash array (CKV_ARGS) instead of string concatenation. Each INPUT_* value becomes exactly one argv element, preventing unintended word-splitting.

Changes:
- entrypoint.sh: Replace string concatenation with bash array (CKV_ARGS)
- action.yml: Use local Dockerfile, remove args block
- Dockerfile: New - builds local image with entrypoint
- Added problem matcher JSON files for local build